### PR TITLE
Handle -dict, more complicated -waveform and ignore -add

### DIFF
--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -806,7 +806,10 @@ struct BaseCtx
 
     NetInfo *getNetByAlias(IdString alias) const
     {
-        return nets.count(alias) ? nets.at(alias).get() : nets.at(net_aliases.at(alias)).get();
+        return nets.count(alias) ? nets.at(alias).get()
+                                 : (net_aliases.count(alias) && nets.count(net_aliases.at(alias))
+                                            ? nets.at(net_aliases.at(alias)).get()
+                                            : nullptr);
     }
 
     void addConstraint(std::unique_ptr<TimingConstraint> constr);


### PR DESCRIPTION
These changes we necessary to get nextpnr to not throw up an error/crash while trying to parse MEGA65-core's [xdc files](https://github.com/LAK132/mega65-core/blob/11933e195fb2d7b47b79a49788e70f22198d138f/src/vhdl/nexys4.xdc). Also gives more useful error messages when there's only 1 argument in the target