### PR TITLE
xilinx: fix IN_USE feature

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -693,7 +693,7 @@ struct FasmBackend
                     write_bit("IN_TERM." + pad->attrs.at(ctx->id("IN_TERM")).as_string());
             }
             if (!is_output)
-                write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL_SSTL135_SSTL15.IN_ONLY");
+                write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVDS_25_LVTTL_SSTL135_SSTL15_TMDS_33.IN_ONLY");
         }
         if (is_input && diff) {
             write_bit("SSTL135_SSTL15.IN_DIFF");


### PR DESCRIPTION
Introduced changes fixes `IN_USE` feature which has changed in the latest prjxray-db.
Current prjxray-db entry has additional `LVDS_25` and `TMDS_33` keywords in mentioned feature.

Signed-off-by: Jan Kowalewski <jkowalewski@antmicro.com>