### PR TITLE
Adapt to updated prjxray filestructure

### DIFF
--- a/xilinx/python/bbaexport.py
+++ b/xilinx/python/bbaexport.py
@@ -25,6 +25,9 @@ def main():
 	if "xc7z" in args.device:
 		metadata_root = metadata_root.replace("artix7", "zynq7")
 		xraydb_root = xraydb_root.replace("artix7", "zynq7")
+	if "xc7k" in args.device:
+		metadata_root = metadata_root.replace("artix7", "kintex7")
+		xraydb_root = xraydb_root.replace("artix7", "kintex7")
 	d = import_device(args.device, xraydb_root, metadata_root)
 	# Import tile types
 	seen_tiletypes = set()

--- a/xilinx/python/xilinx_device.py
+++ b/xilinx/python/xilinx_device.py
@@ -451,11 +451,11 @@ def import_device(name, prjxray_root, metadata_root):
 		return ij["intents"][str(ij["tiles"][tiletype][wirename])]
 
 	d = Device(name)
-	basepart = name.split('t')[0] + "t"
+	fabricname = name.split('t')[0] + "t"
 	# Load intent JSON
 	with open(metadata_root + "/wire_intents.json", "r") as ijf:
 		ij = json.load(ijf)
-	with open(prjxray_root + "/" + basepart + "/tilegrid.json") as gf:
+	with open(prjxray_root + "/" + fabricname + "/tilegrid.json") as gf:
 		tgj = json.load(gf)
 	for tile, tiledata in sorted(tgj.items()):
 		x = int(tiledata["grid_x"])
@@ -494,6 +494,6 @@ def import_device(name, prjxray_root, metadata_root):
 			if sl[2] == "site":
 				continue # header
 			d.sites_by_name[sl[2]].package_pin = sl[0]
-	with open(prjxray_root + "/" + basepart + "/tileconn.json", "r") as tcf:
+	with open(prjxray_root + "/" + fabricname + "/tileconn.json", "r") as tcf:
 		apply_tileconn(tcf, d)
 	return d

--- a/xilinx/python/xilinx_device.py
+++ b/xilinx/python/xilinx_device.py
@@ -451,10 +451,11 @@ def import_device(name, prjxray_root, metadata_root):
 		return ij["intents"][str(ij["tiles"][tiletype][wirename])]
 
 	d = Device(name)
+	basepart = name.split('t')[0] + "t"
 	# Load intent JSON
 	with open(metadata_root + "/wire_intents.json", "r") as ijf:
 		ij = json.load(ijf)
-	with open(prjxray_root + "/" + name + "/tilegrid.json") as gf:
+	with open(prjxray_root + "/" + basepart + "/tilegrid.json") as gf:
 		tgj = json.load(gf)
 	for tile, tiledata in sorted(tgj.items()):
 		x = int(tiledata["grid_x"])
@@ -493,6 +494,6 @@ def import_device(name, prjxray_root, metadata_root):
 			if sl[2] == "site":
 				continue # header
 			d.sites_by_name[sl[2]].package_pin = sl[0]
-	with open(prjxray_root + "/" + name + "/tileconn.json", "r") as tcf:
+	with open(prjxray_root + "/" + basepart + "/tileconn.json", "r") as tcf:
 		apply_tileconn(tcf, d)
 	return d


### PR DESCRIPTION
This pull request addresses changes that are necessary to ensure compatibility with updates at upstream prjxray, cf. https://github.com/kintex-chatter/nextpnr-xilinx/issues/3 and https://github.com/kintex-chatter/nextpnr-xilinx/issues/3#issuecomment-1048851087 in particular:
- prjxray's directory structure used to place these files in the same folder (January 2020): https://github.com/f4pga/prjxray/commit/e44027bcafa943a0f5e492412acf26fae3a3a780#diff-175c465d4f4da9458bab1c732b558ee8b10b087d14d052c160bb827fb7d668f2R17 and https://github.com/f4pga/prjxray/commit/e44027bcafa943a0f5e492412acf26fae3a3a780#diff-2aea961e96499d96f980a17a1110978f3bf66bcc1e4ec1e772aaec71f6932614R43
- In Januar 2021, a commit changed the structure and effectively broke nextpnr-xilinx: https://github.com/f4pga/prjxray/commit/e60b0d587574764e5838f0ef844dd0fc9c460fd9

