### PR TITLE
Packer aborts on failed assertion because of uninitialized Arch.site_by_name

### DIFF
--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -118,8 +118,10 @@ void Arch::setup_byname() const
     if (site_by_name.empty()) {
         for (int i = 0; i < chip_info->num_tiles; i++) {
             auto &tile = chip_info->tile_insts[i];
-            for (int j = 0; j < tile.num_sites; j++)
-                site_by_name[tile.site_insts[j].name.get()] = std::make_pair(i, j);
+            for (int j = 0; j < tile.num_sites; j++) {
+                auto name = tile.site_insts[j].name.get();
+                site_by_name[name] = std::make_pair(i, j);
+            }
         }
     }
 }

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -237,6 +237,10 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
 
 void XC7Packer::pack_io()
 {
+    // make sure the supporting data structure of
+    // get_tilename_by_sitename()
+    // is initialized before we use it below
+    ctx->setup_byname();
 
     log_info("Inserting IO buffers..\n");
 


### PR DESCRIPTION
This causes the resolution of some IO constraints to fail and cause an abort because of failed assertion:
![image](https://user-images.githubusercontent.com/148607/176063161-1ec5ffe6-09a5-49bb-9abe-f27fd4b6d599.png)
The change in arch.cc is optional,
but I think it's easier to read and facilitates debugging.