### PR TITLE
Support for the Kintex High Performance Banks (RIOB18)

### DIFF
--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -352,8 +352,7 @@ void Arch::setup_pip_blacklist()
                     src_name.find("CK_BUFG_CASCIN") != std::string::npos)
                     blacklist_pips[td.type].insert(j);
             }
-        // } else if (boost::starts_with(type, "HCLK_IOI")) {
-	} else if (boost::starts_with(type, "HCLK_IOI")) {
+        } else if (boost::starts_with(type, "HCLK_IOI")) {
             for (int j = 0; j < td.num_pips; j++) {
                 auto &pd = td.pip_data[j];
                 std::string dest_name = IdString(td.wire_data[pd.dst_index].name).str(this);
@@ -363,7 +362,6 @@ void Arch::setup_pip_blacklist()
                     src_name.find("IMUX") != std::string::npos)
                     blacklist_pips[td.type].insert(j);
             }
-	// } else if (type.find("IOI3") != std::string::npos) {
         } else if (type.find("IOI") != std::string::npos) {
             for (int j = 0; j < td.num_pips; j++) {
                 auto &pd = td.pip_data[j];

--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -350,7 +350,8 @@ void Arch::setup_pip_blacklist()
                     src_name.find("CK_BUFG_CASCIN") != std::string::npos)
                     blacklist_pips[td.type].insert(j);
             }
-        } else if (boost::starts_with(type, "HCLK_IOI3")) {
+        // } else if (boost::starts_with(type, "HCLK_IOI")) {
+	} else if (boost::starts_with(type, "HCLK_IOI")) {
             for (int j = 0; j < td.num_pips; j++) {
                 auto &pd = td.pip_data[j];
                 std::string dest_name = IdString(td.wire_data[pd.dst_index].name).str(this);
@@ -360,7 +361,8 @@ void Arch::setup_pip_blacklist()
                     src_name.find("IMUX") != std::string::npos)
                     blacklist_pips[td.type].insert(j);
             }
-        } else if (type.find("IOI3") != std::string::npos) {
+	// } else if (type.find("IOI3") != std::string::npos) {
+        } else if (type.find("IOI") != std::string::npos) {
             for (int j = 0; j < td.num_pips; j++) {
                 auto &pd = td.pip_data[j];
                 std::string dest_name = IdString(td.wire_data[pd.dst_index].name).str(this);

--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -118,8 +118,10 @@ void Arch::setup_byname() const
     if (site_by_name.empty()) {
         for (int i = 0; i < chip_info->num_tiles; i++) {
             auto &tile = chip_info->tile_insts[i];
-            for (int j = 0; j < tile.num_sites; j++)
-                site_by_name[tile.site_insts[j].name.get()] = std::make_pair(i, j);
+            for (int j = 0; j < tile.num_sites; j++) {
+                auto name = tile.site_insts[j].name.get();
+                site_by_name[name] = std::make_pair(i, j);
+            }
         }
     }
 }

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -777,8 +777,8 @@ struct FasmBackend
                 write_bit("IN_TERM." + pad->attrs.at(ctx->id("IN_TERM")).as_string());
         }
 
-        if (!is_riob18 && (iostandard == "LVCMOS12" || iostandard == "LVCMOS15" ||
-	                       iostandard == "LVCMOS18" || iostandard == "SSTL135")) {
+        if (!is_riob18 && (iostandard == "LVCMOS12" || iostandard == "LVCMOS15" || iostandard == "LVCMOS18" ||
+                           iostandard == "SSTL135"  || iostandard == "SSTL15" )) {
             write_bit("LVCMOS12_LVCMOS15_LVCMOS18_SSTL135_SSTL15.STEPDOWN");
             ioconfig_by_hclk[hclk].stepdown = true;
             is_stepdown = true;

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -706,7 +706,15 @@ struct FasmBackend
         if (is_output) {
             if (iostandard == "LVCMOS33" || iostandard == "LVTTL")
                 write_bit("LVCMOS33_LVTTL.DRIVE.I12_I16");
-            if (iostandard == "LVCMOS15" || iostandard == "SSTL15")
+	    if (is_riob18 && (iostandard == "LVCMOS18" || iostandard == "LVCMOS15"))
+	        write_bit("LVCMOS15_LVCMOS18.DRIVE.I12_I16_I2_I4_I6_I8");
+	    else if (is_riob18 && iostandard == "LVCMOS12")
+	        write_bit("LVCMOS12.DRIVE.I2_I4_I6_I8");
+	    else if (is_riob18 && iostandard == "SSTL15")
+                write_bit("SSTL15.DRIVE.I_FIXED");
+	    else if (is_riob18 && iostandard == "LVDS")
+                write_bit("LVDS.DRIVE.I_FIXED");
+            else if (iostandard == "LVCMOS15" || iostandard == "SSTL15")
                 write_bit("LVCMOS15_SSTL15.DRIVE.I16_I_FIXED");
             if (iostandard == "SSTL135")
                 write_bit("SSTL135.DRIVE.I_FIXED");
@@ -724,6 +732,8 @@ struct FasmBackend
         if (is_input && !diff) {
             if (iostandard == "LVCMOS33" || iostandard == "LVTTL" || iostandard == "LVCMOS25")
                 write_bit("LVCMOS25_LVCMOS33_LVTTL.IN");
+	    if (is_riob18 && (iostandard == "LVCMOS18" || iostandard == "LVCMOS15" || iostandard == "LVCMOS12"))
+	        write_bit("LVCMOS12_LVCMOS15_LVCMOS18.IN");
             if (iostandard == "SSTL135" || iostandard == "SSTL15") {
                 ioconfig_by_hclk[hclk].vref = true;
                 write_bit("SSTL135_SSTL15.IN");

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -769,7 +769,7 @@ struct FasmBackend
         std::string site = ctx->getBelSite(pad->bel);
         std::string belname;
         BelId inv;
-	if (0&&is_riob18)
+	if (is_riob18)
 	    inv = ctx->getBelByName(ctx->id(site + "/IOB18S/O_ININV"));
 	else
 	    inv = ctx->getBelByName(ctx->id(site + "/IOB33S/O_ININV"));

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -718,14 +718,19 @@ struct FasmBackend
                 write_bit("LVCMOS15_SSTL15.DRIVE.I16_I_FIXED");
             if (iostandard == "SSTL135")
                 write_bit("SSTL135.DRIVE.I_FIXED");
-            if (slew == "SLOW" && is_riob18)
-                write_bit("LVCMOS12_LVCMOS15_LVCMOS18.SLEW.SLOW");
-	    else if (slew == "SLOW")
+            if (is_riob18 && slew == "SLOW") {
+	        if (iostandard == "SSTL135")
+                    write_bit("SSTL135.SLEW.SLOW");
+	        else if (iostandard == "SSTL15")
+                    write_bit("SSTL15.SLEW.SLOW");
+		else
+                    write_bit("LVCMOS12_LVCMOS15_LVCMOS18.SLEW.SLOW");
+	    } else if (slew == "SLOW")
                 write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL_SSTL135_SSTL15.SLEW.SLOW");
+            else if (is_riob18)
+                write_bit(iostandard + ".SLEW.FAST");
             else if (iostandard == "SSTL135" || iostandard == "SSTL15")
                 write_bit("SSTL135_SSTL15.SLEW.FAST");
-            else if (is_riob18)
-                write_bit("LVCMOS12_LVCMOS15_LVCMOS18.SLEW.FAST");
 	    else
                 write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL.SLEW.FAST");
         }
@@ -749,7 +754,10 @@ struct FasmBackend
                 write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVDS_25_LVTTL_SSTL135_SSTL15_TMDS_33.IN_ONLY");
         }
         if (is_input && diff) {
-            write_bit("SSTL135_SSTL15.IN_DIFF");
+	    if (is_riob18)
+                write_bit("LVDS_SSTL135_SSTL15.IN_DIFF");
+	    else
+                write_bit("SSTL135_SSTL15.IN_DIFF");
             if (pad->attrs.count(ctx->id("IN_TERM")))
                 write_bit("IN_TERM." + pad->attrs.at(ctx->id("IN_TERM")).as_string());
         }

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -690,7 +690,7 @@ struct FasmBackend
         std::string tile = get_tile_name(pad->bel.tile);
         push(tile);
 
-        bool is_riob18 = tile.find("RIOB18_") != std::string::npos;
+	bool is_riob18 = boost::starts_with(tile, "RIOB18_");
         bool is_sing = tile.find("_SING_") != std::string::npos;
         bool is_top_sing = pad->bel.tile < ctx->getHclkForIob(pad->bel);
         bool is_stepdown = false;

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -163,7 +163,7 @@ struct FasmBackend
                     pp_config[{ctx->id("RIOB18" + s2), ctx->id("IOB_T_OUT0"), ctx->id("IOB_T0")}] = {};
                     pp_config[{ctx->id("RIOB18" + s2), ctx->id("IOB_DIFFI_IN0"), ctx->id("IOB_PADOUT1")}] = {};
                 }
-	    }
+        }
 
         for (std::string s1 : {"TOP", "BOT"}) {
             for (std::string s2 : {"L", "R"}) {
@@ -234,8 +234,8 @@ struct FasmBackend
             std::string tile_name = get_tile_name(pip.tile);
             for (auto c : pp) {
                 if (boost::starts_with(tile_name, "RIOI3_SING")
-		    || boost::starts_with(tile_name, "LIOI3_SING")
-		    || boost::starts_with(tile_name, "RIOI_SING")) {
+                    || boost::starts_with(tile_name, "LIOI3_SING")
+                    || boost::starts_with(tile_name, "RIOI_SING")) {
                     // Need to flip for top HCLK
                     bool is_top_sing = pip.tile < ctx->getHclkForIoi(pip.tile);
                     if (is_top_sing) {
@@ -265,8 +265,8 @@ struct FasmBackend
             }
             std::string orig_dst_name = dst_name;
             if (boost::starts_with(tile_name, "RIOI3_SING")
-		|| boost::starts_with(tile_name, "LIOI3_SING")
-		|| boost::starts_with(tile_name, "RIOI_SING")) {
+                || boost::starts_with(tile_name, "LIOI3_SING")
+                || boost::starts_with(tile_name, "RIOI_SING")) {
                 // FIXME: PPIPs missing for SING IOI3s
                 if ((src_name.find("IMUX") != std::string::npos || src_name.find("CTRL0") != std::string::npos) &&
                     (dst_name.find("CLK") == std::string::npos))
@@ -705,9 +705,9 @@ struct FasmBackend
 
         if (is_output) {
             // DRIVE
-	        if (iostandard == "LVCMOS33" || iostandard == "LVTTL") {
+            if (iostandard == "LVCMOS33" || iostandard == "LVTTL") {
                 if (!is_riob18)
-	                write_bit("LVCMOS33_LVTTL.DRIVE.I12_I16");
+                    write_bit("LVCMOS33_LVTTL.DRIVE.I12_I16");
                 else
                     log_error("high performance banks (RIOB18) do not support IO standard %s\n", iostandard.c_str());
             }
@@ -742,7 +742,7 @@ struct FasmBackend
                 write_bit(iostandard + ".SLEW.FAST");
             else if (iostandard == "SSTL135" || iostandard == "SSTL15")
                 write_bit("SSTL135_SSTL15.SLEW.FAST");
-	        else
+            else
                 write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL.SLEW.FAST");
 
             if (!is_riob18 & diff)
@@ -750,9 +750,9 @@ struct FasmBackend
         }
 
         if (is_input && !diff) {
-	        if (iostandard == "LVCMOS33" || iostandard == "LVTTL" || iostandard == "LVCMOS25") {
+            if (iostandard == "LVCMOS33" || iostandard == "LVTTL" || iostandard == "LVCMOS25") {
                 if (!is_riob18)
-	            write_bit("LVCMOS25_LVCMOS33_LVTTL.IN");
+                    write_bit("LVCMOS25_LVCMOS33_LVTTL.IN");
                 else
                     log_error("high performance banks (RIOB18) do not support IO standard %s\n", iostandard.c_str());
             }
@@ -766,11 +766,6 @@ struct FasmBackend
             if (iostandard == "LVCMOS12" || iostandard == "LVCMOS15" || iostandard == "LVCMOS18") {
                 write_bit("LVCMOS12_LVCMOS15_LVCMOS18.IN");
             }
-            if (!is_output && is_riob18)
-                write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVDS_SSTL135_SSTL15.IN_ONLY");
-	    else if (!is_output)
-            write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVDS_25_LVTTL_SSTL135_SSTL15_TMDS_33.IN_ONLY");
-        }
 
             if (!is_output) {
                 if (is_riob18) {
@@ -811,10 +806,10 @@ struct FasmBackend
         std::string belname;
         BelId inv;
 
-	    if (is_riob18)
-	        inv = ctx->getBelByName(ctx->id(site + "/IOB18S/O_ININV"));
-	    else
-	        inv = ctx->getBelByName(ctx->id(site + "/IOB33S/O_ININV"));
+        if (is_riob18)
+            inv = ctx->getBelByName(ctx->id(site + "/IOB18S/O_ININV"));
+        else
+            inv = ctx->getBelByName(ctx->id(site + "/IOB33S/O_ININV"));
 
         if (inv != BelId() && ctx->getBoundBelCell(inv) != nullptr)
             write_bit("OUT_DIFF");
@@ -870,11 +865,11 @@ struct FasmBackend
             }
 #else
             if (type == "DDR")
-	        write_bit("DATA_WIDTH.DDR.W" + std::to_string(width));
-	    else if (type == "SDR")
-	        write_bit("DATA_WIDTH.SDR.W" + std::to_string(width));
-	    else
-	        write_bit("DATA_WIDTH.W" + std::to_string(width));
+            write_bit("DATA_WIDTH.DDR.W" + std::to_string(width));
+        else if (type == "SDR")
+            write_bit("DATA_WIDTH.SDR.W" + std::to_string(width));
+        else
+            write_bit("DATA_WIDTH.W" + std::to_string(width));
 #endif
             write_bit("SRTYPE.SYNC");
             write_bit("TSRTYPE.SYNC");

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -705,42 +705,47 @@ struct FasmBackend
         int hclk = ctx->getHclkForIob(pad->bel);
 
         if (is_output) {
-            if (iostandard == "LVCMOS33" || iostandard == "LVTTL")
-                write_bit("LVCMOS33_LVTTL.DRIVE.I12_I16");
-	    if (is_riob18 && (iostandard == "LVCMOS18" || iostandard == "LVCMOS15"))
-	        write_bit("LVCMOS15_LVCMOS18.DRIVE.I12_I16_I2_I4_I6_I8");
-	    else if (is_riob18 && iostandard == "LVCMOS12")
-	        write_bit("LVCMOS12.DRIVE.I2_I4_I6_I8");
-	    else if (is_riob18 && iostandard == "SSTL15")
+	        if (iostandard == "LVCMOS33" || iostandard == "LVTTL")
+	            write_bit("LVCMOS33_LVTTL.DRIVE.I12_I16");
+
+	        if (is_riob18 && (iostandard == "LVCMOS18" || iostandard == "LVCMOS15"))
+	            write_bit("LVCMOS15_LVCMOS18.DRIVE.I12_I16_I2_I4_I6_I8");
+	        else if (is_riob18 && iostandard == "LVCMOS12")
+	            write_bit("LVCMOS12.DRIVE.I2_I4_I6_I8");
+	        else if (is_riob18 && iostandard == "SSTL15")
                 write_bit("SSTL15.DRIVE.I_FIXED");
-	    else if (is_riob18 && iostandard == "LVDS")
+	        else if (is_riob18 && iostandard == "LVDS")
                 write_bit("LVDS.DRIVE.I_FIXED");
             else if (iostandard == "LVCMOS15" || iostandard == "SSTL15")
                 write_bit("LVCMOS15_SSTL15.DRIVE.I16_I_FIXED");
+
             if (iostandard == "SSTL135")
                 write_bit("SSTL135.DRIVE.I_FIXED");
+
             if (is_riob18 && slew == "SLOW") {
-	        if (iostandard == "SSTL135")
+                if (iostandard == "SSTL135")
                     write_bit("SSTL135.SLEW.SLOW");
-	        else if (iostandard == "SSTL15")
+                else if (iostandard == "SSTL15")
                     write_bit("SSTL15.SLEW.SLOW");
-		else
+                else
                     write_bit("LVCMOS12_LVCMOS15_LVCMOS18.SLEW.SLOW");
-	    } else if (slew == "SLOW")
+            } else if (slew == "SLOW")
                 write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL_SSTL135_SSTL15.SLEW.SLOW");
             else if (is_riob18)
                 write_bit(iostandard + ".SLEW.FAST");
             else if (iostandard == "SSTL135" || iostandard == "SSTL15")
                 write_bit("SSTL135_SSTL15.SLEW.FAST");
-	    else
+	        else
                 write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL.SLEW.FAST");
         }
-        if (is_input && !diff) {
-            if (iostandard == "LVCMOS33" || iostandard == "LVTTL" || iostandard == "LVCMOS25")
-                write_bit("LVCMOS25_LVCMOS33_LVTTL.IN");
 
-	    if (is_riob18 && (iostandard == "LVCMOS18" || iostandard == "LVCMOS15" || iostandard == "LVCMOS12"))
-	        write_bit("LVCMOS12_LVCMOS15_LVCMOS18.IN");
+        if (is_input && !diff) {
+	        if (iostandard == "LVCMOS33" || iostandard == "LVTTL" || iostandard == "LVCMOS25")
+	            write_bit("LVCMOS25_LVCMOS33_LVTTL.IN");
+
+	        if (is_riob18 && (iostandard == "LVCMOS18" || iostandard == "LVCMOS15" || iostandard == "LVCMOS12"))
+	            write_bit("LVCMOS12_LVCMOS15_LVCMOS18.IN");
+
             if (iostandard == "SSTL135" || iostandard == "SSTL15") {
                 ioconfig_by_hclk[hclk].vref = true;
                 write_bit("SSTL135_SSTL15.IN");
@@ -756,7 +761,13 @@ struct FasmBackend
             write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVDS_25_LVTTL_SSTL135_SSTL15_TMDS_33.IN_ONLY");
         }
 
-        if (is_input && diff) {
+            if (!is_output) {
+                if (is_riob18)
+                    write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVDS_SSTL135_SSTL15.IN_ONLY");
+                else
+                    write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVDS_25_LVTTL_SSTL135_SSTL15_TMDS_33.IN_ONLY");
+            }
+        } else if (is_input && diff) {
             if (is_riob18)
                 write_bit("LVDS_SSTL135_SSTL15.IN_DIFF");
             else

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -289,7 +289,6 @@ struct FasmBackend
                     }
                 }
             }
-            //if (tile_name.find("IOI3") != std::string::npos) {
             if (tile_name.find("IOI") != std::string::npos) {
                 if (dst_name.find("OCLKB") != std::string::npos && src_name.find("IOI_OCLKM_") != std::string::npos)
                     return; // missing, not sure if really a ppip?
@@ -299,7 +298,6 @@ struct FasmBackend
             out << dst_name << ".";
             out << src_name << std::endl;
 
-            //if (tile_name.find("IOI3") != std::string::npos && boost::starts_with(dst_name, "IOI_OCLK_")) {
             if (tile_name.find("IOI") != std::string::npos && boost::starts_with(dst_name, "IOI_OCLK_")) {
                 dst_name.insert(dst_name.find("OCLK") + 4, 1, 'M');
                 orig_dst_name.insert(dst_name.find("OCLK") + 4, 1, 'M');

--- a/xilinx/pack_carry_xc7.cc
+++ b/xilinx/pack_carry_xc7.cc
@@ -240,7 +240,8 @@ void XC7Packer::pack_carries()
                 c4->constr_parent = root;
                 root->constr_children.push_back(c4);
                 c4->constr_x = 0;
-                c4->constr_y = -i / 4;
+		// Looks no CARRY4 on the tile of which grid_y is a multiple of 26. Skip them
+                c4->constr_y = -(i / 4 + i / (4*25));
                 c4->constr_abs_z = true;
                 c4->constr_z = BEL_CARRY4;
             }
@@ -345,7 +346,7 @@ void XC7Packer::pack_carries()
                 root->constr_children.push_back(s_lut);
                 s_lut->constr_parent = root;
                 s_lut->constr_x = 0;
-                s_lut->constr_y = -i / 4;
+                s_lut->constr_y = -(i / 4 + i / (4*25));
                 s_lut->constr_abs_z = true;
                 s_lut->constr_z = (z << 4 | BEL_6LUT);
             }
@@ -353,7 +354,7 @@ void XC7Packer::pack_carries()
                 root->constr_children.push_back(di_lut);
                 di_lut->constr_parent = root;
                 di_lut->constr_x = 0;
-                di_lut->constr_y = -i / 4;
+                di_lut->constr_y = -(i / 4 + i / (4*25));
                 di_lut->constr_abs_z = true;
                 di_lut->constr_z = (z << 4 | BEL_5LUT);
             }

--- a/xilinx/pack_carry_xc7.cc
+++ b/xilinx/pack_carry_xc7.cc
@@ -240,7 +240,7 @@ void XC7Packer::pack_carries()
                 c4->constr_parent = root;
                 root->constr_children.push_back(c4);
                 c4->constr_x = 0;
-		// Looks no CARRY4 on the tile of which grid_y is a multiple of 26. Skip them
+                // Looks no CARRY4 on the tile of which grid_y is a multiple of 26. Skip them
                 c4->constr_y = -(i / 4 + i / (4*25));
                 c4->constr_abs_z = true;
                 c4->constr_z = BEL_CARRY4;

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -514,7 +514,16 @@ std::string XC7Packer::get_idelay_site(const std::string &io_bel)
 
 std::string XC7Packer::get_ioctrl_site(const std::string &io_bel)
 {
-    BelId pad_bel = ctx->getBelByName(ctx->id(io_bel.substr(0, io_bel.find('/')) + "/IOB33/PAD"));
+    std::vector<std::string> parts;
+    boost::split(parts, io_bel, boost::is_any_of("/"));
+    auto loc         = parts[0];
+    auto iobank      = parts[1];
+    auto pad_bel_str = loc + "/" + iobank + "/PAD";
+    auto msg         = "could not get bel for: '" + pad_bel_str + "'";
+
+    BelId pad_bel = ctx->getBelByName(ctx->id(pad_bel_str));
+    NPNR_ASSERT_MSG(0 <= pad_bel.tile && 0 <= pad_bel.index, msg.c_str());
+
     int hclk_tile = ctx->getHclkForIob(pad_bel);
     auto &td = ctx->chip_info->tile_insts[hclk_tile];
     for (int i = 0; i < td.num_sites; i++) {

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -106,7 +106,7 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
 
         CellInfo *inbuf = insert_ibuf(int_name(xil_iob->name, "IBUF", is_se_iobuf), ibuf_type, pad_net, top_out);
 	std::string tile = get_tilename_by_sitename(ctx, site);
-	//log_info("decompose_io: Tile '%s'\n", tile.c_str());
+	log_info("decompose_io: Tile '%s'\n", tile.c_str());
 	if (boost::starts_with(tile, "RIOB18_"))
 	    inbuf->attrs[ctx->id("BEL")] = site + "/IOB18/INBUF_DCIEN";
 	else
@@ -119,7 +119,7 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
     }
 
     if (is_se_obuf || is_se_iobuf) {
-        log_info("Generating output buffer for '%s'\n", xil_iob->name.c_str(ctx));
+        log_info("Generating output buffer for ===> '%s'\n", xil_iob->name.c_str(ctx));
         NetInfo *pad_net = get_net_or_empty(xil_iob, is_se_iobuf ? ctx->id("IO") : ctx->id("O"));
         NPNR_ASSERT(pad_net != nullptr);
         std::string site = pad_site(pad_net);
@@ -131,7 +131,7 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
                 is_se_iobuf ? (has_dci ? ctx->id("OBUFT_DCIEN") : ctx->id("OBUFT")) : xil_iob->type,
                 get_net_or_empty(xil_iob, ctx->id("I")), pad_net, get_net_or_empty(xil_iob, ctx->id("T")));
 	std::string tile = get_tilename_by_sitename(ctx, site);
-	//log_info("decompose_io: Tile '%s'\n", tile.c_str());
+	log_info("decompose_io: Tile '%s'\n", tile.c_str());
 	if (boost::starts_with(tile, "RIOB18_"))
 	    obuf->attrs[ctx->id("BEL")] = site + "/IOB18/OUTBUF_DCIEN";
 	else
@@ -312,11 +312,11 @@ void XC7Packer::pack_io()
                           loc.c_str());
             log_info("    Constraining '%s' to site '%s'\n", pad->name.c_str(ctx), site.c_str());
 	    std::string tile = get_tilename_by_sitename(ctx, site);
-	    //log_info("    Tile '%s'\n", tile.c_str());
+	    log_info("    Tile '%s'\n", tile.c_str());
 	    if (boost::starts_with(tile, "RIOB18_"))
 	        pad->attrs[ctx->id("BEL")] = std::string(site + "/IOB18/PAD");
 	    else
-                pad->attrs[ctx->id("BEL")] = std::string(site + "/IOB33/PAD");
+            pad->attrs[ctx->id("BEL")] = std::string(site + "/IOB33/PAD");
         }
         if (pad->attrs.count(ctx->id("BEL"))) {
             used_io_bels.insert(ctx->getBelByName(ctx->id(pad->attrs.at(ctx->id("BEL")).as_string())));

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -283,6 +283,10 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
 
 void XC7Packer::pack_io()
 {
+    // make sure the supporting data structure of
+    // get_tilename_by_sitename()
+    // is initialized before we use it below
+    ctx->setup_byname();
 
     log_info("Inserting IO buffers..\n");
 

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -119,7 +119,7 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
     }
 
     if (is_se_obuf || is_se_iobuf) {
-        log_info("Generating output buffer for ===> '%s'\n", xil_iob->name.c_str(ctx));
+        log_info("Generating output buffer for '%s'\n", xil_iob->name.c_str(ctx));
         NetInfo *pad_net = get_net_or_empty(xil_iob, is_se_iobuf ? ctx->id("IO") : ctx->id("O"));
         NPNR_ASSERT(pad_net != nullptr);
         std::string site = pad_site(pad_net);

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -106,7 +106,6 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
 
         CellInfo *inbuf = insert_ibuf(int_name(xil_iob->name, "IBUF", is_se_iobuf), ibuf_type, pad_net, top_out);
         std::string tile = get_tilename_by_sitename(ctx, site);
-        log_info("decompose_io: Tile '%s'\n", tile.c_str());
         if (boost::starts_with(tile, "RIOB18_"))
             inbuf->attrs[ctx->id("BEL")] = site + "/IOB18/INBUF_DCIEN";
         else
@@ -131,7 +130,6 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
                 is_se_iobuf ? (has_dci ? ctx->id("OBUFT_DCIEN") : ctx->id("OBUFT")) : xil_iob->type,
                 get_net_or_empty(xil_iob, ctx->id("I")), pad_net, get_net_or_empty(xil_iob, ctx->id("T")));
         std::string tile = get_tilename_by_sitename(ctx, site);
-        log_info("decompose_io: Tile '%s'\n", tile.c_str());
         if (boost::starts_with(tile, "RIOB18_"))
             obuf->attrs[ctx->id("BEL")] = site + "/IOB18/OUTBUF_DCIEN";
         else
@@ -162,7 +160,6 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
         NPNR_ASSERT(pad_n_net != nullptr);
         std::string site_n = pad_site(pad_n_net);
         std::string tile_p = get_tilename_by_sitename(ctx, site_p);
-        //log_info("decompose_io: Tile '%s'\n", tile_p.c_str());
         bool is_riob18 = boost::starts_with(tile_p, "RIOB18_");
 
         if (!is_diff_iobuf && !is_diff_out_iobuf) {
@@ -199,7 +196,6 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
         NPNR_ASSERT(pad_n_net != nullptr);
         std::string site_n = pad_site(pad_n_net);
         std::string tile_p = get_tilename_by_sitename(ctx, site_p);
-        //log_info("decompose_io: Tile '%s'\n", tile_p.c_str());
         bool is_riob18 = boost::starts_with(tile_p, "RIOB18_");
 
         disconnect_port(ctx, xil_iob, (is_diff_iobuf || is_diff_out_iobuf) ? ctx->id("IO") : ctx->id("O"));

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -376,45 +376,55 @@ void XC7Packer::pack_io()
     hriobuf_rules[ctx->id("OBUF")].port_xform[ctx->id("I")] = ctx->id("IN");
     hriobuf_rules[ctx->id("OBUF")].port_xform[ctx->id("O")] = ctx->id("OUT");
     hriobuf_rules[ctx->id("OBUF")].port_xform[ctx->id("T")] = ctx->id("TRI");
+    hriobuf_rules[ctx->id("OBUFT")] = hriobuf_rules[ctx->id("OBUF")];
+
     hriobuf_rules[ctx->id("IBUF")].new_type = ctx->id("IOB33_INBUF_EN");
     hriobuf_rules[ctx->id("IBUF")].port_xform[ctx->id("I")] = ctx->id("PAD");
     hriobuf_rules[ctx->id("IBUF")].port_xform[ctx->id("O")] = ctx->id("OUT");
+    hriobuf_rules[ctx->id("IBUF_INTERMDISABLE")] = hriobuf_rules[ctx->id("IBUF")];
+    hriobuf_rules[ctx->id("IBUF_IBUFDISABLE")] = hriobuf_rules[ctx->id("IBUF")];
+    hriobuf_rules[ctx->id("IBUFDS_INTERMDISABLE_INT")] = hriobuf_rules[ctx->id("IBUF")];
+    hriobuf_rules[ctx->id("IBUFDS_INTERMDISABLE_INT")].port_xform[ctx->id("IB")] = ctx->id("DIFFI_IN");
+    hriobuf_rules[ctx->id("IBUFDS")] = hriobuf_rules[ctx->id("IBUF")];
+    hriobuf_rules[ctx->id("IBUFDS")].port_xform[ctx->id("IB")] = ctx->id("DIFFI_IN");
 
     hpiobuf_rules[ctx->id("OBUF")].new_type = ctx->id("IOB18_OUTBUF_DCIEN");
     hpiobuf_rules[ctx->id("OBUF")].port_xform[ctx->id("I")] = ctx->id("IN");
     hpiobuf_rules[ctx->id("OBUF")].port_xform[ctx->id("O")] = ctx->id("OUT");
     hpiobuf_rules[ctx->id("OBUF")].port_xform[ctx->id("T")] = ctx->id("TRI");
+    hpiobuf_rules[ctx->id("OBUFT")] = hpiobuf_rules[ctx->id("OBUF")];
+
     hpiobuf_rules[ctx->id("IBUF")].new_type = ctx->id("IOB18_INBUF_DCIEN");
     hpiobuf_rules[ctx->id("IBUF")].port_xform[ctx->id("I")] = ctx->id("PAD");
     hpiobuf_rules[ctx->id("IBUF")].port_xform[ctx->id("O")] = ctx->id("OUT");
+    hpiobuf_rules[ctx->id("IBUF_INTERMDISABLE")] = hpiobuf_rules[ctx->id("IBUF")];
+    hpiobuf_rules[ctx->id("IBUF_IBUFDISABLE")] = hpiobuf_rules[ctx->id("IBUF")];
+    hriobuf_rules[ctx->id("IBUFDS_INTERMDISABLE_INT")] = hriobuf_rules[ctx->id("IBUF")];
+    hpiobuf_rules[ctx->id("IBUFDS_INTERMDISABLE_INT")].port_xform[ctx->id("IB")] = ctx->id("DIFFI_IN");
+    hpiobuf_rules[ctx->id("IBUFDS")] = hpiobuf_rules[ctx->id("IBUF")];
+    hpiobuf_rules[ctx->id("IBUFDS")].port_xform[ctx->id("IB")] = ctx->id("DIFFI_IN");
 
-    // Special xform for OBUF and Ibuf.
+    // Special xform for OBUFx and IBUFx.
     std::unordered_map<IdString, XFormRule> rules;
     for (auto cell : sorted(ctx->cells)) {
         CellInfo *ci = cell.second;
-        if (ci->type == ctx->id("IBUF") || ci->type == ctx->id("OBUF")) {
-	    std::string belname = ci->attrs[ctx->id("BEL")].c_str();
-	    size_t pos = belname.find("/");
-	    if (belname.substr(pos+1, 5) == "IOB18")
-	        rules = hpiobuf_rules;
-	    else if (belname.substr(pos+1, 5) == "IOB33")
-	        rules = hriobuf_rules;
-	    else
-	        log_error("Unexpected IOBUF BEL %s\n", belname.c_str());
+	if (!ci->attrs.count(ctx->id("BEL")))
+	    continue;
+	std::string belname = ci->attrs[ctx->id("BEL")].c_str();
+	size_t pos = belname.find("/");
+	if (belname.substr(pos+1, 5) == "IOB18")
+	    rules = hpiobuf_rules;
+	else if (belname.substr(pos+1, 5) == "IOB33")
+	    rules = hriobuf_rules;
+	else
+	    log_error("Unexpected IOBUF BEL %s\n", belname.c_str());
+        if (rules.count(ci->type)) {
             xform_cell(rules, ci);
         }
     }
 
     std::unordered_map<IdString, XFormRule> hrio_rules;
     hrio_rules[ctx->id("PAD")].new_type = ctx->id("PAD");
-    hrio_rules[ctx->id("OBUFT")] = hrio_rules[ctx->id("OBUF")];
-
-    hrio_rules[ctx->id("IBUF_INTERMDISABLE")] = hrio_rules[ctx->id("IBUF")];
-    hrio_rules[ctx->id("IBUF_IBUFDISABLE")] = hrio_rules[ctx->id("IBUF")];
-    hrio_rules[ctx->id("IBUFDS_INTERMDISABLE_INT")] = hrio_rules[ctx->id("IBUF")];
-    hrio_rules[ctx->id("IBUFDS_INTERMDISABLE_INT")].port_xform[ctx->id("IB")] = ctx->id("DIFFI_IN");
-    hrio_rules[ctx->id("IBUFDS")] = hrio_rules[ctx->id("IBUF")];
-    hrio_rules[ctx->id("IBUFDS")].port_xform[ctx->id("IB")] = ctx->id("DIFFI_IN");
 
     hrio_rules[ctx->id("INV")].new_type = ctx->id("INVERTER");
     hrio_rules[ctx->id("INV")].port_xform[ctx->id("I")] = ctx->id("IN");

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -589,7 +589,8 @@ void XC7Packer::pack_iologic()
                 log_error("%s '%s' has disconnected IDATAIN input\n", ci->type.c_str(ctx), ctx->nameOf(ci));
             CellInfo *drv = d->driver.cell;
             BelId io_bel;
-            if (drv->type.str(ctx).find("INBUF_EN") != std::string::npos)
+            if (drv->type.str(ctx).find("INBUF_EN") != std::string::npos
+		|| drv->type.str(ctx).find("INBUF_DCIEN") != std::string::npos)
                 io_bel = ctx->getBelByName(ctx->id(drv->attrs.at(ctx->id("BEL")).as_string()));
             else
                 log_error("%s '%s' has IDATAIN input connected to illegal cell type %s\n", ci->type.c_str(ctx),
@@ -673,7 +674,8 @@ void XC7Packer::pack_iologic()
                 if (d == nullptr || d->driver.cell == nullptr)
                     log_error("%s '%s' has disconnected D input\n", ci->type.c_str(ctx), ctx->nameOf(ci));
                 CellInfo *drv = d->driver.cell;
-                if (drv->type.str(ctx).find("INBUF_EN") != std::string::npos)
+                if (drv->type.str(ctx).find("INBUF_EN") != std::string::npos
+		    || drv->type.str(ctx).find("INBUF_DCIEN") != std::string::npos)
                     io_bel = ctx->getBelByName(ctx->id(drv->attrs.at(ctx->id("BEL")).as_string()));
                 else
                     log_error("%s '%s' has D input connected to illegal cell type %s\n", ci->type.c_str(ctx),

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -59,7 +59,7 @@ std::string get_tilename_by_sitename(Context *ctx, std::string site)
     if (ctx->site_by_name.count(site)) {
         int tile, siteid;
         std::tie(tile, siteid) = ctx->site_by_name.at(site);
-	return ctx->chip_info->tile_insts[tile].name.get();
+        return ctx->chip_info->tile_insts[tile].name.get();
     }
     return std::string();
 }
@@ -105,11 +105,11 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
             ibuf_type = ctx->id("IBUF_INTERMDISABLE");
 
         CellInfo *inbuf = insert_ibuf(int_name(xil_iob->name, "IBUF", is_se_iobuf), ibuf_type, pad_net, top_out);
-	std::string tile = get_tilename_by_sitename(ctx, site);
-	log_info("decompose_io: Tile '%s'\n", tile.c_str());
-	if (boost::starts_with(tile, "RIOB18_"))
-	    inbuf->attrs[ctx->id("BEL")] = site + "/IOB18/INBUF_DCIEN";
-	else
+        std::string tile = get_tilename_by_sitename(ctx, site);
+        log_info("decompose_io: Tile '%s'\n", tile.c_str());
+        if (boost::starts_with(tile, "RIOB18_"))
+            inbuf->attrs[ctx->id("BEL")] = site + "/IOB18/INBUF_DCIEN";
+        else
             inbuf->attrs[ctx->id("BEL")] = site + "/IOB33/INBUF_EN";
         replace_port(xil_iob, ctx->id("IBUFDISABLE"), inbuf, ctx->id("IBUFDISABLE"));
         replace_port(xil_iob, ctx->id("INTERMDISABLE"), inbuf, ctx->id("INTERMDISABLE"));
@@ -130,11 +130,11 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
                          !is_se_obuf),
                 is_se_iobuf ? (has_dci ? ctx->id("OBUFT_DCIEN") : ctx->id("OBUFT")) : xil_iob->type,
                 get_net_or_empty(xil_iob, ctx->id("I")), pad_net, get_net_or_empty(xil_iob, ctx->id("T")));
-	std::string tile = get_tilename_by_sitename(ctx, site);
-	log_info("decompose_io: Tile '%s'\n", tile.c_str());
-	if (boost::starts_with(tile, "RIOB18_"))
-	    obuf->attrs[ctx->id("BEL")] = site + "/IOB18/OUTBUF_DCIEN";
-	else
+        std::string tile = get_tilename_by_sitename(ctx, site);
+        log_info("decompose_io: Tile '%s'\n", tile.c_str());
+        if (boost::starts_with(tile, "RIOB18_"))
+            obuf->attrs[ctx->id("BEL")] = site + "/IOB18/OUTBUF_DCIEN";
+        else
             obuf->attrs[ctx->id("BEL")] = site + "/IOB33/OUTBUF";
         replace_port(xil_iob, ctx->id("DCITERMDISABLE"), obuf, ctx->id("DCITERMDISABLE"));
         if (is_se_iobuf)
@@ -161,9 +161,9 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
                 get_net_or_empty(xil_iob, (is_diff_iobuf || is_diff_out_iobuf) ? ctx->id("IOB") : ctx->id("IB"));
         NPNR_ASSERT(pad_n_net != nullptr);
         std::string site_n = pad_site(pad_n_net);
-	std::string tile_p = get_tilename_by_sitename(ctx, site_p);
-	//log_info("decompose_io: Tile '%s'\n", tile_p.c_str());
-	bool is_riob18 = boost::starts_with(tile_p, "RIOB18_");
+        std::string tile_p = get_tilename_by_sitename(ctx, site_p);
+        //log_info("decompose_io: Tile '%s'\n", tile_p.c_str());
+        bool is_riob18 = boost::starts_with(tile_p, "RIOB18_");
 
         if (!is_diff_iobuf && !is_diff_out_iobuf) {
             disconnect_port(ctx, xil_iob, ctx->id("I"));
@@ -176,13 +176,13 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
         IdString ibuf_type = ctx->id("IBUFDS");
         CellInfo *inbuf = insert_diffibuf(int_name(xil_iob->name, "IBUF", is_se_iobuf), ibuf_type,
                                           {pad_p_net, pad_n_net}, top_out);
-	if (is_riob18) {
+        if (is_riob18) {
             inbuf->attrs[ctx->id("BEL")] = site_p + "/IOB18M/INBUF_DCIEN";
             inbuf->attrs[ctx->id("X_IOB_SITE_TYPE")] = std::string("IOB18M");
-	} else {
+        } else {
             inbuf->attrs[ctx->id("BEL")] = site_p + "/IOB33M/INBUF_EN";
             inbuf->attrs[ctx->id("X_IOB_SITE_TYPE")] = std::string("IOB33M");
-	}
+        }
 
         if (is_diff_iobuf)
             subcells.push_back(inbuf);
@@ -198,9 +198,9 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
                 get_net_or_empty(xil_iob, (is_diff_iobuf || is_diff_out_iobuf) ? ctx->id("IOB") : ctx->id("OB"));
         NPNR_ASSERT(pad_n_net != nullptr);
         std::string site_n = pad_site(pad_n_net);
-	std::string tile_p = get_tilename_by_sitename(ctx, site_p);
+        std::string tile_p = get_tilename_by_sitename(ctx, site_p);
         //log_info("decompose_io: Tile '%s'\n", tile_p.c_str());
-	bool is_riob18 = boost::starts_with(tile_p, "RIOB18_");
+        bool is_riob18 = boost::starts_with(tile_p, "RIOB18_");
 
         disconnect_port(ctx, xil_iob, (is_diff_iobuf || is_diff_out_iobuf) ? ctx->id("IO") : ctx->id("O"));
         disconnect_port(ctx, xil_iob, (is_diff_iobuf || is_diff_out_iobuf) ? ctx->id("IOB") : ctx->id("OB"));
@@ -208,13 +208,13 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
         NetInfo *inv_i = create_internal_net(xil_iob->name, is_diff_obuf ? "I_B" : "OBUFTDS$subnet$I_B");
         CellInfo *inv = insert_outinv(int_name(xil_iob->name, is_diff_obuf ? "INV" : "OBUFTDS$subcell$INV"),
                                       get_net_or_empty(xil_iob, ctx->id("I")), inv_i);
-	if (is_riob18) {
+        if (is_riob18) {
             inv->attrs[ctx->id("BEL")] = site_n + "/IOB18S/O_ININV";
             inv->attrs[ctx->id("X_IOB_SITE_TYPE")] = std::string("IOB18S");
-	} else {
+        } else {
             inv->attrs[ctx->id("BEL")] = site_n + "/IOB33S/O_ININV";
             inv->attrs[ctx->id("X_IOB_SITE_TYPE")] = std::string("IOB33S");
-	}
+        }
 
         bool has_dci = xil_iob->type == ctx->id("IOBUFDS_DCIEN") || xil_iob->type == ctx->id("IOBUFDSE3");
 
@@ -225,13 +225,13 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
                                        get_net_or_empty(xil_iob, ctx->id("I")), pad_p_net,
                                        get_net_or_empty(xil_iob, ctx->id("T")));
 
-	if (is_riob18) {
+        if (is_riob18) {
             obuf_p->attrs[ctx->id("BEL")] = site_p + "/IOB18M/OUTBUF_DCIEN";
             obuf_p->attrs[ctx->id("X_IOB_SITE_TYPE")] = std::string("IOB18M");
-	} else {
+        } else {
             obuf_p->attrs[ctx->id("BEL")] = site_p + "/IOB33M/OUTBUF";
             obuf_p->attrs[ctx->id("X_IOB_SITE_TYPE")] = std::string("IOB33M");
-	}
+        }
         subcells.push_back(obuf_p);
         connect_port(ctx, get_net_or_empty(xil_iob, ctx->id("DCITERMDISABLE")), obuf_p, ctx->id("DCITERMDISABLE"));
 
@@ -241,13 +241,13 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
                                                : ctx->id("OBUF"),
                                        inv_i, pad_n_net, get_net_or_empty(xil_iob, ctx->id("T")));
 
-	if (is_riob18) {
+        if (is_riob18) {
             obuf_n->attrs[ctx->id("BEL")] = site_n + "/IOB18S/OUTBUF_DCIEN";
             obuf_n->attrs[ctx->id("X_IOB_SITE_TYPE")] = std::string("IOB18S");
-	} else {
+        } else {
             obuf_n->attrs[ctx->id("BEL")] = site_n + "/IOB33S/OUTBUF";
             obuf_n->attrs[ctx->id("X_IOB_SITE_TYPE")] = std::string("IOB33S");
-	}
+        }
         connect_port(ctx, get_net_or_empty(xil_iob, ctx->id("DCITERMDISABLE")), obuf_n, ctx->id("DCITERMDISABLE"));
 
         disconnect_port(ctx, xil_iob, ctx->id("DCITERMDISABLE"));
@@ -315,12 +315,12 @@ void XC7Packer::pack_io()
                 log_error("Unable to constrain IO '%s', device does not have a pin named '%s'\n", pad->name.c_str(ctx),
                           loc.c_str());
             log_info("    Constraining '%s' to site '%s'\n", pad->name.c_str(ctx), site.c_str());
-	    std::string tile = get_tilename_by_sitename(ctx, site);
-	    log_info("    Tile '%s'\n", tile.c_str());
-	    if (boost::starts_with(tile, "RIOB18_"))
-	        pad->attrs[ctx->id("BEL")] = std::string(site + "/IOB18/PAD");
-	    else
-            pad->attrs[ctx->id("BEL")] = std::string(site + "/IOB33/PAD");
+            std::string tile = get_tilename_by_sitename(ctx, site);
+            log_info("    Tile '%s'\n", tile.c_str());
+            if (boost::starts_with(tile, "RIOB18_"))
+                pad->attrs[ctx->id("BEL")] = std::string(site + "/IOB18/PAD");
+            else
+                pad->attrs[ctx->id("BEL")] = std::string(site + "/IOB33/PAD");
         }
         if (pad->attrs.count(ctx->id("BEL"))) {
             used_io_bels.insert(ctx->getBelByName(ctx->id(pad->attrs.at(ctx->id("BEL")).as_string())));
@@ -402,16 +402,16 @@ void XC7Packer::pack_io()
     std::unordered_map<IdString, XFormRule> rules;
     for (auto cell : sorted(ctx->cells)) {
         CellInfo *ci = cell.second;
-	if (!ci->attrs.count(ctx->id("BEL")))
-	    continue;
-	std::string belname = ci->attrs[ctx->id("BEL")].c_str();
-	size_t pos = belname.find("/");
-	if (belname.substr(pos+1, 5) == "IOB18")
-	    rules = hpiobuf_rules;
-	else if (belname.substr(pos+1, 5) == "IOB33")
-	    rules = hriobuf_rules;
-	else
-	    log_error("Unexpected IOBUF BEL %s\n", belname.c_str());
+        if (!ci->attrs.count(ctx->id("BEL")))
+            continue;
+        std::string belname = ci->attrs[ctx->id("BEL")].c_str();
+        size_t pos = belname.find("/");
+        if (belname.substr(pos+1, 5) == "IOB18")
+            rules = hpiobuf_rules;
+        else if (belname.substr(pos+1, 5) == "IOB33")
+            rules = hriobuf_rules;
+        else
+            log_error("Unexpected IOBUF BEL %s\n", belname.c_str());
         if (rules.count(ci->type)) {
             xform_cell(rules, ci);
         }
@@ -566,7 +566,7 @@ void XC7Packer::pack_iologic()
         for (auto &usr : net->users) {
             IdString type = usr.cell->type;
             if (type == ctx->id("IOB33_OUTBUF") || type == ctx->id("IOB33M_OUTBUF")
-		|| type == ctx->id("IOB18_OUTBUF_DCIEN") || type == ctx->id("IOB18M_OUTBUF_DCIEN")) {
+                || type == ctx->id("IOB18_OUTBUF_DCIEN") || type == ctx->id("IOB18M_OUTBUF_DCIEN")) {
                 if (outbuf != nullptr)
                     return (CellInfo *)nullptr; // drives multiple outputs
                 outbuf = usr.cell;
@@ -584,7 +584,7 @@ void XC7Packer::pack_iologic()
             CellInfo *drv = d->driver.cell;
             BelId io_bel;
             if (drv->type.str(ctx).find("INBUF_EN") != std::string::npos
-		|| drv->type.str(ctx).find("INBUF_DCIEN") != std::string::npos)
+                || drv->type.str(ctx).find("INBUF_DCIEN") != std::string::npos)
                 io_bel = ctx->getBelByName(ctx->id(drv->attrs.at(ctx->id("BEL")).as_string()));
             else
                 log_error("%s '%s' has IDATAIN input connected to illegal cell type %s\n", ci->type.c_str(ctx),
@@ -634,7 +634,7 @@ void XC7Packer::pack_iologic()
                     log_error("%s '%s' has disconnected D input\n", ci->type.c_str(ctx), ctx->nameOf(ci));
                 CellInfo *drv = d->driver.cell;
                 if (drv->type.str(ctx).find("INBUF_EN") != std::string::npos
-		    || drv->type.str(ctx).find("INBUF_DCIEN") != std::string::npos)
+                    || drv->type.str(ctx).find("INBUF_DCIEN") != std::string::npos)
                     io_bel = ctx->getBelByName(ctx->id(drv->attrs.at(ctx->id("BEL")).as_string()));
                 else
                     log_error("%s '%s' has D input connected to illegal cell type %s\n", ci->type.c_str(ctx),

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -438,7 +438,11 @@ void XC7Packer::pack_io()
 
 std::string XC7Packer::get_ologic_site(const std::string &io_bel)
 {
-    BelId ibc_bel = ctx->getBelByName(ctx->id(io_bel.substr(0, io_bel.find('/')) + "/IOB33/OUTBUF"));
+    BelId ibc_bel;
+    if (io_bel.find("IOB18") != std::string::npos)
+        ibc_bel = ctx->getBelByName(ctx->id(io_bel.substr(0, io_bel.find('/')) + "/IOB18/OUTBUF_DCIEN"));
+    else
+        ibc_bel = ctx->getBelByName(ctx->id(io_bel.substr(0, io_bel.find('/')) + "/IOB33/OUTBUF"));
     std::queue<WireId> visit;
     visit.push(ctx->getBelPinWire(ibc_bel, ctx->id("IN")));
 
@@ -458,7 +462,11 @@ std::string XC7Packer::get_ologic_site(const std::string &io_bel)
 
 std::string XC7Packer::get_ilogic_site(const std::string &io_bel)
 {
-    BelId ibc_bel = ctx->getBelByName(ctx->id(io_bel.substr(0, io_bel.find('/')) + "/IOB33/INBUF_EN"));
+    BelId ibc_bel;
+    if (io_bel.find("IOB18") != std::string::npos)
+        ibc_bel = ctx->getBelByName(ctx->id(io_bel.substr(0, io_bel.find('/')) + "/IOB18/INBUF_DCIEN"));
+    else
+      ibc_bel = ctx->getBelByName(ctx->id(io_bel.substr(0, io_bel.find('/')) + "/IOB33/INBUF_EN"));
     std::queue<WireId> visit;
     visit.push(ctx->getBelPinWire(ibc_bel, ctx->id("OUT")));
 
@@ -478,7 +486,11 @@ std::string XC7Packer::get_ilogic_site(const std::string &io_bel)
 
 std::string XC7Packer::get_idelay_site(const std::string &io_bel)
 {
-    BelId ibc_bel = ctx->getBelByName(ctx->id(io_bel.substr(0, io_bel.find('/')) + "/IOB33/INBUF_EN"));
+    BelId ibc_bel;
+    if (io_bel.find("IOB18") != std::string::npos)
+        ibc_bel = ctx->getBelByName(ctx->id(io_bel.substr(0, io_bel.find('/')) + "/IOB18/INBUF_DCIEN"));
+    else
+      ibc_bel = ctx->getBelByName(ctx->id(io_bel.substr(0, io_bel.find('/')) + "/IOB33/INBUF_EN"));
     std::queue<WireId> visit;
     visit.push(ctx->getBelPinWire(ibc_bel, ctx->id("OUT")));
 
@@ -549,7 +561,8 @@ void XC7Packer::pack_iologic()
         CellInfo *outbuf = nullptr;
         for (auto &usr : net->users) {
             IdString type = usr.cell->type;
-            if (type == ctx->id("IOB33_OUTBUF") || type == ctx->id("IOB33M_OUTBUF")) {
+            if (type == ctx->id("IOB33_OUTBUF") || type == ctx->id("IOB33M_OUTBUF")
+		|| type == ctx->id("IOB18_OUTBUF_DCIEN") || type == ctx->id("IOB18M_OUTBUF_DCIEN")) {
                 if (outbuf != nullptr)
                     return (CellInfo *)nullptr; // drives multiple outputs
                 outbuf = usr.cell;

--- a/xilinx/python/nextpnr_structs.py
+++ b/xilinx/python/nextpnr_structs.py
@@ -356,7 +356,7 @@ class NextpnrTileType:
 		name = bel.name()
 		bt = bel.bel_type()
 		prim_st = site.primary.site_type()
-		if prim_st in ("IOB33M", "IOB33S", "IOB33"):
+		if prim_st in ("IOB33M", "IOB33S", "IOB33", "IOB18M", "IOB18S", "IOB18"):
 			name = site.site_type() + "/" + name
 		nb = NextpnrBel(
 			name=name, index=len(self.bels), 


### PR DESCRIPTION
This provides support for the high performance banks available on Kintex (and also Virtex).
It enables the use of the toolchain eg on the Genesys2 board, which has a differential clock input on
a high performance bank.
This pull request corresponds to this pull request in prjxray, which very likely will be merged soon:
https://github.com/f4pga/prjxray/pull/2046
This also has been tested on hardware, and the results are encouraging:
https://github.com/f4pga/prjxray/pull/2046#issuecomment-1323023987
If you want to try out the changes quickly, without manually compiling,
I have built a toolchain installer based on snap packages:
https://github.com/kintex-chatter/toolchain-installer

There are blinkys for several boards here,
using the snap toolchain:
https://github.com/kintex-chatter/demo-projects/tree/main/blinky-stlv7325

There are also demos for various boards here
and the Makefile contains the previous toolchain installer
https://github.com/kintex-chatter/xc7k325t-blinky-nextpnr/

There is also an ongoing pull request for integration into edalize:
https://github.com/olofk/edalize/pull/308
