### PR TITLE
Don't generate OUT_DIFF inside part of the IO tile, which does not exist

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -751,9 +751,6 @@ struct FasmBackend
                 write_bit("SSTL135_SSTL15.SLEW.FAST");
             else
                 write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL.SLEW.FAST");
-
-            if (!is_riob18 & diff)
-                write_bit("OUT_DIFF");
         }
 
         if (is_input) {


### PR DESCRIPTION
This bit actually does not exist inside Y0/Y1 of the IO tile.