### PR TITLE
xilinx/python/xilinx_device: fix fabricname extraction

### DIFF
--- a/xilinx/python/xilinx_device.py
+++ b/xilinx/python/xilinx_device.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from tileconn import apply_tileconn
 from parse_sdf import parse_sdf_file
 # Represents Xilinx device data from PrjXray etc
@@ -451,7 +452,11 @@ def import_device(name, prjxray_root, metadata_root):
 		return ij["intents"][str(ij["tiles"][tiletype][wirename])]
 
 	d = Device(name)
-	fabricname = name.split('t')[0] + "t"
+	match = re.search("^(xc7[akz]\d+t?)\w+-\d", name)
+	if not match:
+		raise RuntimeError("{} is not known device name".format(name))
+	fabricname = match.groups()[0]
+
 	if fabricname == 'xc7a35t':
 		# https://github.com/gatecat/nextpnr-xilinx/issues/35
 		# https://github.com/f4pga/prjxray/pull/1889


### PR DESCRIPTION
Since commit https://github.com/gatecat/nextpnr-xilinx/commit/565588a69ea95a52f7c7592f4ed81d9bef6cfb60 `fabricname` is built by splitting `name` using **t** followed by adding a **t** at the end.
This is fine for **artix7** and **kintex7** but not for **zynq7** or **spartan7**.

This PR replace the split by a regex to extract base name (without package and speed grade) to have a solution compatible with all devices currently supported.