### PR TITLE
xilinx/fasm.cc: fix regression (broken DDR3 on high range banks), and other bugs

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -780,7 +780,7 @@ struct FasmBackend
                     // vivado generates these bits only for Y0 of a diff pair
                     if (yLoc == 0) {
                         write_bit("LVDS_SSTL12_SSTL135_SSTL15.IN_DIFF");
-                        if (iostandard == "LVDS" || boost::contains(iostandard, "SSTL"))
+                        if (iostandard == "LVDS")
                             write_bit("LVDS.IN_USE");
                     }
                 } else {

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -691,18 +691,17 @@ struct FasmBackend
         bool is_sing = tile.find("_SING_") != std::string::npos;
         bool is_top_sing = pad->bel.tile < ctx->getHclkForIob(pad->bel);
         bool is_stepdown = false;
-        bool is_sstl = iostandard == "SSTL12" || iostandard == "SSTL135" || iostandard == "SSTL15";
-        bool is_diff_sstl = iostandard == "DIFF_SSTL12" || iostandard == "DIFF_SSTL135" || iostandard == "DIFF_SSTL15";
         bool is_lvcmos = iostandard == "LVCMOS12" || iostandard == "LVCMOS15" || iostandard == "LVCMOS18";
 
         auto yLoc = is_sing ? (is_top_sing ? 1 : 0) : (1 - ioLoc.y);
         push("IOB_Y" + std::to_string(yLoc));
 
-        bool diff = false;
+        bool is_diff = false;
         if (boost::starts_with(iostandard, "DIFF_") || iostandard == "LVDS") {
-            diff = true;
+            is_diff = true;
             iostandard.erase(0, 5);
         }
+        bool is_sstl = iostandard == "SSTL12" || iostandard == "SSTL135" || iostandard == "SSTL15";
 
         int hclk = ctx->getHclkForIob(pad->bel);
 
@@ -722,11 +721,9 @@ struct FasmBackend
                     write_bit("LVCMOS12.DRIVE.I2_I4_I6_I8");
                 else if (iostandard == "LVDS")
                     write_bit("LVDS.DRIVE.I_FIXED");
-                else if (is_sstl || is_diff_sstl) {
-                    auto iostd = iostandard;
-                    if (boost::starts_with(iostandard, "DIFF_"))
-                        iostd = iostandard.substr(5);
-                    write_bit(iostd + ".DRIVE.I_FIXED");
+                else if (is_sstl) {
+                    write_bit(iostandard + ".DRIVE.I_FIXED");
+                    write_bit(iostandard + ".IN_USE");
                 }
             }
             else if (iostandard == "LVCMOS15" || iostandard == "SSTL15")
@@ -754,7 +751,7 @@ struct FasmBackend
         }
 
         if (is_input) {
-            if (!diff) {
+            if (!is_diff) {
                 if (iostandard == "LVCMOS33" || iostandard == "LVTTL" || iostandard == "LVCMOS25") {
                     if (!is_riob18)
                         write_bit("LVCMOS25_LVCMOS33_LVTTL.IN");
@@ -778,7 +775,7 @@ struct FasmBackend
                 if (is_lvcmos) {
                     write_bit("LVCMOS12_LVCMOS15_LVCMOS18.IN");
                 }
-            } else /* diff */ {
+            } else /* is_diff */ {
                 if (is_riob18) {
                     // vivado generates these bits only for Y0 of a diff pair
                     if (yLoc == 0) {
@@ -798,7 +795,7 @@ struct FasmBackend
             if (!is_output) {
                 if (is_riob18) {
                     // vivado also sets this bit for DIFF_SSTL
-                    if (diff && (yLoc == 0))
+                    if (is_diff && (yLoc == 0))
                         write_bit("LVDS.IN_ONLY");
                     else
                         write_bit("LVCMOS12_LVCMOS15_LVCMOS18_SSTL12_SSTL135_SSTL15.IN_ONLY");
@@ -808,13 +805,13 @@ struct FasmBackend
         }
 
         if (!is_riob18 && (is_lvcmos || is_sstl)) {
-            if (iostandard == "SSTL12")
+            if (iostandard == "SSTL12") {
                 log_error("SSTL12 is only available on high performance banks.");
+            }
             write_bit("LVCMOS12_LVCMOS15_LVCMOS18_SSTL135_SSTL15.STEPDOWN");
             ioconfig_by_hclk[hclk].stepdown = true;
             is_stepdown = true;
         }
-
 
         if (is_riob18 && (is_input || is_output) && (boost::contains(iostandard, "SSTL") || iostandard == "LVDS")) {
             if (((yLoc == 0) && (iostandard == "LVDS")) ||
@@ -824,7 +821,7 @@ struct FasmBackend
             }
         }
 
-        if (is_input && is_output && !diff && yLoc == 1) {
+        if (is_input && is_output && !is_diff && yLoc == 1) {
             if (is_riob18 && boost::starts_with(iostandard, "SSTL"))
                 write_bit("SSTL12_SSTL135_SSTL15.IN");
         }

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -696,11 +696,9 @@ struct FasmBackend
         auto yLoc = is_sing ? (is_top_sing ? 1 : 0) : (1 - ioLoc.y);
         push("IOB_Y" + std::to_string(yLoc));
 
-        bool is_diff = false;
-        if (boost::starts_with(iostandard, "DIFF_") || iostandard == "LVDS") {
-            is_diff = true;
-            iostandard.erase(0, 5);
-        }
+        bool has_diff_prefix = boost::starts_with(iostandard, "DIFF_");
+        bool is_diff = iostandard == "LVDS" || has_diff_prefix;
+        if (has_diff_prefix) iostandard.erase(0, 5);
         bool is_sstl = iostandard == "SSTL12" || iostandard == "SSTL135" || iostandard == "SSTL15";
 
         int hclk = ctx->getHclkForIob(pad->bel);


### PR DESCRIPTION
Some important fixes. DDR3 works again on K420T (high range banks).
