### PR TITLE
DDR3 is now working on the high performance banks

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -762,7 +762,7 @@ struct FasmBackend
                     if (!is_riob18)
                         write_bit("SSTL135_SSTL15.IN");
 
-                    if (is_riob18 && yLoc == 1) {
+                    if (is_riob18) {
                         write_bit("SSTL12_SSTL135_SSTL15.IN");
                     }
 


### PR DESCRIPTION
Great news!
This complements finding the last missing bits in prjxray to get DDR3 working on the high performance banks!
![image](https://user-images.githubusercontent.com/148607/207724588-fae75cbb-e489-4a73-9bca-854da44b257f.png)
![image](https://user-images.githubusercontent.com/148607/207724626-4b36db53-4fad-4eef-b48d-c2f0446995aa.png)
