### PR TITLE
Implementation of the DRIVE attribute of IO pads

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -733,7 +733,7 @@ struct FasmBackend
                          (iostandard == "LVTTL"    && drive == 16))
                     write_bit("LVCMOS33_LVTTL.DRIVE.I12_I16");
                 else if ((iostandard == "LVCMOS33" && drive == 8) ||
-                         (iostandard == "LVTTL"    && drive == 12))
+                         (iostandard == "LVTTL"    && (drive == 12 | drive == 8)))
                     write_bit("LVCMOS33_LVTTL.DRIVE.I12_I8");
                 else if ((iostandard == "LVCMOS33" && drive == 4) ||
                          (iostandard == "LVTTL"    && drive == 4))

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -745,7 +745,7 @@ struct FasmBackend
                          (iostandard == "LVCMOS15" || iostandard == "LVCMOS18" || iostandard == "LVCMOS25"))
                     write_bit("LVCMOS15_LVCMOS18_LVCMOS25.DRIVE.I4");
                 else if (is_lvcmos || iostandard == "LVTTL")
-                    write_bit(iostandard + ".I" + std::to_string(drive));
+                    write_bit(iostandard + ".DRIVE.I" + std::to_string(drive));
             }
 
             // SSTL output used

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -729,11 +729,11 @@ struct FasmBackend
                     write_bit("LVCMOS15_SSTL15.DRIVE.I16_I_FIXED");
                 else if (iostandard == "LVCMOS18" && (drive == 12 || drive == 8))
                     write_bit("LVCMOS18.DRIVE.I12_I8");
-                else if ((iostandard == "LVCMOS33" && drive == 12) ||
+                else if ((iostandard == "LVCMOS33" && drive == 16) ||
                          (iostandard == "LVTTL"    && drive == 16))
                     write_bit("LVCMOS33_LVTTL.DRIVE.I12_I16");
-                else if ((iostandard == "LVCMOS33" && drive == 8) ||
-                         (iostandard == "LVTTL"    && (drive == 12 | drive == 8)))
+                else if ((iostandard == "LVCMOS33" && (drive == 8 || drive == 12)) ||
+                         (iostandard == "LVTTL"    && (drive == 8 || drive == 12)))
                     write_bit("LVCMOS33_LVTTL.DRIVE.I12_I8");
                 else if ((iostandard == "LVCMOS33" && drive == 4) ||
                          (iostandard == "LVTTL"    && drive == 4))

--- a/xilinx/pack.h
+++ b/xilinx/pack.h
@@ -239,6 +239,9 @@ struct XC7Packer : public XilinxPacker
 
     // DSP
     void pack_dsps();
+
+private:
+    void check_valid_pad(CellInfo *ci, std::string type);
 };
 
 NEXTPNR_NAMESPACE_END

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -141,9 +141,6 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
 
     bool is_diff_ibuf = xil_iob->type == ctx->id("IBUFDS") || xil_iob->type == ctx->id("IBUFDS_INTERMDISABLE") ||
                         xil_iob->type == ctx->id("IBUFDS");
-    bool is_diff_out_ibuf = xil_iob->type == ctx->id("IBUFDS_DIFF_OUT") ||
-                            xil_iob->type == ctx->id("IBUFDS_DIFF_OUT_IBUFDISABLE") ||
-                            xil_iob->type == ctx->id("IBUFDS_DIFF_OUT_INTERMDISABLE");
     bool is_diff_iobuf = xil_iob->type == ctx->id("IOBUFDS") || xil_iob->type == ctx->id("IOBUFDS_DCIEN");
     bool is_diff_out_iobuf = xil_iob->type == ctx->id("IOBUFDS_DIFF_OUT") ||
                              xil_iob->type == ctx->id("IOBUFDS_DIFF_OUT_DCIEN") ||


### PR DESCRIPTION
This is a rather comprehensive implementation based on the manual on one
side and prjxray on the other side.
Without it, it could happen that the output would not work because the drive feature was missing.
