### PR TITLE
Add Spartan7 support

### DIFF
--- a/xilinx/pins.cc
+++ b/xilinx/pins.cc
@@ -17,6 +17,8 @@
  *
  */
 
+#include <set>
+
 #include "nextpnr.h"
 
 NEXTPNR_NAMESPACE_BEGIN

--- a/xilinx/python/bbaexport.py
+++ b/xilinx/python/bbaexport.py
@@ -28,6 +28,9 @@ def main():
 	if "xc7k" in args.device:
 		metadata_root = metadata_root.replace("artix7", "kintex7")
 		xraydb_root = xraydb_root.replace("artix7", "kintex7")
+	if "xc7s" in args.device:
+		metadata_root = metadata_root.replace("artix7", "spartan7")
+		xraydb_root = xraydb_root.replace("artix7", "spartan7")
 	d = import_device(args.device, xraydb_root, metadata_root)
 	# Import tile types
 	seen_tiletypes = set()

--- a/xilinx/python/xilinx_device.py
+++ b/xilinx/python/xilinx_device.py
@@ -452,7 +452,7 @@ def import_device(name, prjxray_root, metadata_root):
 		return ij["intents"][str(ij["tiles"][tiletype][wirename])]
 
 	d = Device(name)
-	match = re.search("^(xc7[akz]\d+t?)\w+-\d", name)
+	match = re.search("^(xc7[sakz]\d+t?)\w+-\d", name)
 	if not match:
 		raise RuntimeError("{} is not known device name".format(name))
 	fabricname = match.groups()[0]


### PR DESCRIPTION
Spartan7 can now build a LiteX SoC with DDR3 memory:
```
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2022 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Feb 21 2023 16:58:52
 BIOS CRC passed (1ccbb977)

 LiteX git sha1: 106b2caa

--=============== SoC ==================--
CPU:		VexRiscv @ 100MHz
BUS:		WISHBONE 32-bit @ 4GiB
CSR:		32-bit data
ROM:		128.0KiB
SRAM:		8.0KiB
L2:		8.0KiB
SDRAM:		256.0MiB 16-bit @ 800MT/s (CL-7 CWL-5)
MAIN-RAM:	256.0MiB

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Read leveling:
  m0, b00: |00000000000000000000000000000000| delays: -
  m0, b01: |00000000000000000000000000000000| delays: -
  m0, b02: |11111111111100000000000000000000| delays: 05+-05
  m0, b03: |00000000000000011111111111110000| delays: 21+-06
  m0, b04: |00000000000000000000000000000001| delays: -
  m0, b05: |00000000000000000000000000000000| delays: -
  m0, b06: |00000000000000000000000000000000| delays: -
  m0, b07: |00000000000000000000000000000000| delays: -
  best: m0, b03 delays: 21+-06
  m1, b00: |00000000000000000000000000000000| delays: -
  m1, b01: |00000000000000000000000000000000| delays: -
  m1, b02: |11111111111110000000000000000000| delays: 06+-06
  m1, b03: |00000000000000011111111111110000| delays: 20+-05
  m1, b04: |00000000000000000000000000000000| delays: -
  m1, b05: |00000000000000000000000000000000| delays: -
  m1, b06: |00000000000000000000000000000000| delays: -
  m1, b07: |00000000000000000000000000000000| delays: -
  best: m1, b03 delays: 21+-06
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 37.0MiB/s
   Read speed: 48.7MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
             Timeout
No boot medium found

--============= Console ================--

litex> ident
Ident: LiteX SoC on Arty S7 2023-02-21 16:58:45
```