### PR TITLE
Assert/Debug fixes

### DIFF
--- a/common/kernel/idstring.cc
+++ b/common/kernel/idstring.cc
@@ -42,8 +42,11 @@ const char *IdString::c_str(const BaseCtx *ctx) const { return str(ctx).c_str();
 
 void IdString::initialize_add(const BaseCtx *ctx, const char *s, int idx)
 {
-    NPNR_ASSERT(ctx->idstring_str_to_idx->count(s) == 0);
-    NPNR_ASSERT(int(ctx->idstring_idx_to_str->size()) == idx);
+    char const *msg = "The internal IDs of nextpnr are inconsistent with the supplied chip database.\n"
+                      "This is usually the case, when the chip database was generated with an older version of nextpnr.\n"
+                      "We recommend regenerating the chip database with this version of nextpnr.\n";
+    NPNR_ASSERT_MSG(ctx->idstring_str_to_idx->count(s) == 0, msg);
+    NPNR_ASSERT_MSG(int(ctx->idstring_idx_to_str->size()) == idx, msg);
     auto insert_rc = ctx->idstring_str_to_idx->insert({s, idx});
     ctx->idstring_idx_to_str->push_back(&insert_rc.first->first);
 }

--- a/xilinx/arch_place.cc
+++ b/xilinx/arch_place.cc
@@ -318,10 +318,14 @@ bool Arch::xc7_logic_tile_valid(IdString tileType, LogicTileStatus &lts) const
 
             // Check 6LUT
             if (lut6 != nullptr) {
-                if (!is_slicem && (lut6->lutInfo.is_memory || lut6->lutInfo.is_srl))
-                    return false; // Memory and SRLs only valid in SLICEMs
-                if (lut6->lutInfo.is_srl && (i >= 4))
+                if (!is_slicem && (lut6->lutInfo.is_memory || lut6->lutInfo.is_srl)) {
+                    DBG();
                     return false;
+                } // Memory and SRLs only valid in SLICEMs
+                if (lut6->lutInfo.is_srl && (i >= 4)) {
+                    DBG();
+                    return false;
+                }
                 if (lut6->lutInfo.is_memory || lut6->lutInfo.is_srl) {
                     if (wclk == nullptr)
                         wclk = lut6->lutInfo.wclk;
@@ -514,6 +518,7 @@ bool Arch::xc7_logic_tile_valid(IdString tileType, LogicTileStatus &lts) const
 
             lts.eights[i].valid = true;
         } else if (!lts.eights[i].valid) {
+            DBG();
             return false;
         }
     }
@@ -545,27 +550,45 @@ bool Arch::xc7_logic_tile_valid(IdString tileType, LogicTileStatus &lts) const
                     CellInfo *ff = lts.cells[z << 4 | (BEL_FF + k)];
                     if (ff == nullptr)
                         continue;
-                    if (ff->ffInfo.is_latch && k == 1)
+                    if (ff->ffInfo.is_latch && k == 1) {
+                        DBG();
                         return false;
+                    }
                     if (found_ff[0] || found_ff[1]) {
-                        if (ff->ffInfo.clk != clk)
+                        if (ff->ffInfo.clk != clk) {
+                            DBG();
                             return false;
-                        if (ff->ffInfo.sr != sr)
+                        }
+                        if (ff->ffInfo.sr != sr) {
+                            DBG();
                             return false;
-                        if (ff->ffInfo.ce != ce)
+                        }
+                        if (ff->ffInfo.ce != ce) {
+                            DBG();
                             return false;
-                        if (ff->ffInfo.is_clkinv != clkinv)
+                        }
+                        if (ff->ffInfo.is_clkinv != clkinv) {
+                            DBG();
                             return false;
-                        if (ff->ffInfo.is_srinv != srinv)
+                        }
+                        if (ff->ffInfo.is_srinv != srinv) {
+                            DBG();
                             return false;
-                        if (ff->ffInfo.is_latch != islatch)
+                        }
+                        if (ff->ffInfo.is_latch != islatch) {
+                            DBG();
                             return false;
-                        if (ff->ffInfo.ffsync != ffsync)
+                        }
+                        if (ff->ffInfo.ffsync != ffsync) {
+                            DBG();
                             return false;
+                        }
                     } else {
                         clk = ff->ffInfo.clk;
-                        if (i == 0 && wclk != nullptr && clk != wclk)
+                        if (i == 0 && wclk != nullptr && clk != wclk) {
+                            DBG();
                             return false;
+                        }
                         sr = ff->ffInfo.sr;
                         ce = ff->ffInfo.ce;
                         clkinv = ff->ffInfo.is_clkinv;
@@ -578,6 +601,7 @@ bool Arch::xc7_logic_tile_valid(IdString tileType, LogicTileStatus &lts) const
             }
             lts.halfs[i].valid = true;
         } else if (!lts.halfs[i].valid) {
+            DBG();
             return false;
         }
     }
@@ -622,8 +646,10 @@ bool Arch::isBelLocationValid(BelId bel, bool explain_invalid) const
         }
     } else {
         for (auto bel : getBelsByTile(bel.tile % chip_info->width, bel.tile / chip_info->width))
-            if (getBoundBelCell(bel) != nullptr && usp_bel_hard_unavail(bel))
+            if (getBoundBelCell(bel) != nullptr && usp_bel_hard_unavail(bel)) {
+                DBG();
                 return false;
+            }
     }
     return true;
 }

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -292,7 +292,7 @@ void XC7Packer::pack_io()
             pad->attrs[id_LOC] = pad->attrs.at(id_PACKAGE_PIN);
         }
         if (pad->attrs.count(id_LOC)) {
-            std::string loc = pad->attrs.at(id_LOC).as_string();
+            std::string loc = pad->attrs.at(id_LOC).to_string();
             std::string site = ctx->getPackagePinSite(loc);
             if (site.empty())
                 log_error("Unable to constrain IO '%s', device does not have a pin named '%s'\n", pad->name.c_str(ctx),


### PR DESCRIPTION
Here are some fixes to the internal debugging.
The assert in idstring.cc is highly user relevant though.
Because the users think nextpnr-xilinx is broken, when
their chip database is only out of date.
