### PR TITLE
Boost lib no longer has convenience.hpp

### DIFF
--- a/bba/main.cc
+++ b/bba/main.cc
@@ -19,7 +19,7 @@
  */
 
 #include <assert.h>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <iostream>
 #include <map>

--- a/common/kernel/command.cc
+++ b/common/kernel/command.cc
@@ -29,7 +29,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/join.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
On Archlinux at least, the patch is needed to support latest boost package.