### PR TITLE
XDC parsing improvements imported from nextpnr-himbaechel

### DIFF
--- a/common/kernel/basectx.h
+++ b/common/kernel/basectx.h
@@ -213,7 +213,11 @@ struct BaseCtx
 
     NetInfo *getNetByAlias(IdString alias) const
     {
-        return nets.count(alias) ? nets.at(alias).get() : nets.at(net_aliases.at(alias)).get();
+        if (nets.count(alias) > 0)
+            return nets.at(alias).get();
+        if (net_aliases.count(alias) == 0)
+            return nullptr;
+        return nets.at(net_aliases.at(alias)).get();
     }
 
     // Intended to simplify Python API

--- a/xilinx/xdc.cc
+++ b/xilinx/xdc.cc
@@ -17,8 +17,11 @@
  *
  */
 
+#include <boost/algorithm/string.hpp>
+
 #include "log.h"
 #include "nextpnr.h"
+
 NEXTPNR_NAMESPACE_BEGIN
 
 void Arch::parseXdc(std::istream &in)
@@ -26,9 +29,12 @@ void Arch::parseXdc(std::istream &in)
 
     if (!in)
         log_error("failed to open LPF file\n");
+
+    log_info("Parsing XDC file...\n");
     std::string line;
     std::string linebuf;
     int lineno = 0;
+    unsigned num_errors = 0;
 
     auto isempty = [](const std::string &str) {
         return std::all_of(str.begin(), str.end(), [](char c) { return std::isspace(c); });
@@ -96,8 +102,10 @@ void Arch::parseXdc(std::istream &in)
 
     auto get_nets = [&](std::string str) {
         std::vector<NetInfo *> tgt_nets;
-        if (str.empty() || str.front() != '[')
-            log_error("failed to parse target (on line %d)\n", lineno);
+        if (str.empty())
+            return tgt_nets;
+        if (str.front() != '[' || str.back() != ']')
+            log_error("failed to parse target '%s' (on line %d)\n", str.c_str(), lineno);
         str = str.substr(1, str.size() - 2);
         auto split = split_to_args(str, false);
         if (split.size() < 1)
@@ -106,8 +114,19 @@ void Arch::parseXdc(std::istream &in)
             log_error("targets other than 'get_ports' or 'get_nets' are not supported (on line %d)\n", lineno);
         if (split.size() < 2)
             log_error("failed to parse target (on line %d)\n", lineno);
-        IdString netname = id(split.at(1));
+        str = strip_quotes(split.at(1));
+        if (str.empty())
+            return tgt_nets;
+        IdString netname = id(str);
         NetInfo *maybe_net = getNetByAlias(netname);
+        if (maybe_net != nullptr) {
+            tgt_nets.push_back(maybe_net);
+            return tgt_nets;
+        }
+        // Also test the lowercase variant, for better interoperability with synthesis tools
+        boost::algorithm::to_lower(str);
+        netname = id(str);
+        maybe_net = getNetByAlias(netname);
         if (maybe_net != nullptr)
             tgt_nets.push_back(maybe_net);
         return tgt_nets;
@@ -126,62 +145,119 @@ void Arch::parseXdc(std::istream &in)
         if (arguments.empty())
             continue;
         std::string &cmd = arguments.front();
+
         if (cmd == "set_property") {
             std::vector<std::pair<std::string, std::string>> arg_pairs;
-            if (arguments.size() != 4)
-                log_error("expected four arguments to 'set_property' (on line %d)\n", lineno);
+            if (arguments.size() < 4) {
+                log_nonfatal_error("expected at least four arguments to 'set_property' (on line %d)\n", lineno);
+                num_errors++;
+                goto nextline;
+            }
             else if (arguments.at(1) == "-dict") {
                 std::vector<std::string> dict_args = split_to_args(strip_quotes(arguments.at(2)), false);
-                if ((dict_args.size() % 2) != 0)
-                    log_error("expected an even number of argument for dictionary (on line %d)\n", lineno);
+                if ((dict_args.size() % 2) != 0) {
+                    log_nonfatal_error("expected an even number of argument for dictionary (on line %d)\n", lineno);
+                    num_errors++;
+                    goto nextline;
+                }
                 arg_pairs.reserve(dict_args.size() / 2);
                 for (int cursor = 0; cursor + 1 < int(dict_args.size()); cursor += 2) {
                     arg_pairs.emplace_back(std::move(dict_args.at(cursor)), std::move(dict_args.at(cursor + 1)));
                 }
-            } else
+            } else {
                 arg_pairs.emplace_back(std::move(arguments.at(1)), std::move(arguments.at(2)));
-            if (arguments.at(1) == "INTERNAL_VREF")
+            }
+            // Warning : ug835 has lowercase example, so probably supporting lowercase too is needed
+            if (arg_pairs.size() == 1 && arg_pairs.front().first == "INTERNAL_VREF") { // get_iobanks not supported
+                log_warning("INTERNAL_VREF isn't supported, ignoring (on line %d)\n", lineno);
                 continue;
+            }
             if (arguments.at(3).size() > 2 && arguments.at(3) == "[current_design]") {
                 log_warning("[current_design] isn't supported, ignoring (on line %d)\n", lineno);
                 continue;
             }
-            std::vector<CellInfo *> dest = get_cells(arguments.at(3));
-            for (auto c : dest)
-                for (const auto &pair : arg_pairs)
-                    c->attrs[id(pair.first)] = std::string(pair.second);
+            // All remaining arguments are supposed to designate cells
+            std::vector<CellInfo *> dest;
+            for (int cursor = 3; cursor < int(arguments.size()); cursor++) {
+                std::vector<CellInfo *> dest_loc = get_cells(arguments.at(cursor));
+                if (dest_loc.empty())
+                    log_warning("found set_property with no cells matching '%s' (on line %d)\n", arguments.at(cursor).c_str(), lineno);
+                dest.insert(dest.end(), dest_loc.begin(), dest_loc.end());
+            }
+            for (auto c : dest) {
+                for (const auto &pair : arg_pairs) {
+                    IdString id_prop = id(pair.first);
+                    //if (ctx->debug)
+                    //    log_info("applying property '%s' = '%s' to cell '%s' (on line %d)\n", pair.first.c_str(), pair.second.c_str(), c->name.c_str(this), lineno);
+                    if(c->attrs.find(id_prop) != c->attrs.end()) {
+                        log_nonfatal_error("found multiple properties '%s' for cell '%s' (on line %d)\n", pair.first.c_str(), c->name.c_str(this), lineno);
+                        num_errors++;
+                    }
+                    c->attrs[id_prop] = std::string(pair.second);
+                }
+            }
         } else if (cmd == "create_clock") {
             double period = 0;
             bool got_period = false;
             int cursor = 1;
             for (cursor = 1; cursor < int(arguments.size()); cursor++) {
                 std::string opt = arguments.at(cursor);
-                if (opt == "-add")
-                    ;
-                else if (opt == "-name" || opt == "-waveform")
+                if (opt == "-add") {
+                    log_warning("ignoring unsupported XDC option '%s' (on line %d)\n", opt.c_str(), lineno);
+                }
+                else if (opt == "-name" || opt == "-waveform") {
+                    log_warning("ignoring unsupported XDC option '%s' (on line %d)\n", opt.c_str(), lineno);
                     cursor++;
+                }
                 else if (opt == "-period") {
                     cursor++;
                     period = std::stod(arguments.at(cursor));
                     got_period = true;
-                } else
+                }
+                else
                     break;
             }
-            if (!got_period)
-                log_error("found create_clock without period (on line %d)", lineno);
-            std::vector<NetInfo *> dest = get_nets(arguments.at(cursor));
+            if (!got_period) {
+                log_nonfatal_error("found create_clock without period (on line %d)\n", lineno);
+                num_errors++;
+                goto nextline;
+            }
+            // All remaining arguments are supposed to designate ports/nets
+            std::vector<NetInfo *> dest;
+            if (cursor >= int(arguments.size()))
+                log_warning("found create_clock without designated nets (on line %d)\n", lineno);
+            for ( ; cursor < (int)arguments.size(); cursor++) {
+                std::vector<NetInfo *> dest_loc = get_nets(arguments.at(cursor));
+                if (dest_loc.empty())
+                    log_warning("found create_clock with no nets matching '%s' (on line %d)\n", arguments.at(cursor).c_str(), lineno);
+                dest.insert(dest.end(), dest_loc.begin(), dest_loc.end());
+            }
             for (auto n : dest) {
+                //if (ctx->debug)
+                //    log_info("applying clock period constraint on net '%s' (on line %d)\n", n->name.c_str(this), lineno);
+                if (n->clkconstr.get() != nullptr) {
+                    log_nonfatal_error("found multiple clock constraints on net '%s' (on line %d)\n", n->name.c_str(this), lineno);
+                    num_errors++;
+                }
                 n->clkconstr = std::unique_ptr<ClockConstraint>(new ClockConstraint);
                 n->clkconstr->period = DelayPair(getDelayFromNS(period));
                 n->clkconstr->high = DelayPair(getDelayFromNS(period / 2));
                 n->clkconstr->low = DelayPair(getDelayFromNS(period / 2));
             }
         } else {
-            log_info("ignoring unsupported XDC command '%s' (on line %d)\n", cmd.c_str(), lineno);
+            log_warning("ignoring unsupported XDC command '%s' (on line %d)\n", cmd.c_str(), lineno);
         }
+
+        nextline:
+        ;  // Phony statement to have something legal after the label
     }
-    if (!isempty(linebuf))
-        log_error("unexpected end of XDC file\n");
+    if (!isempty(linebuf)) {
+        log_nonfatal_error("unexpected end of XDC file\n");
+        num_errors++;
+    }
+    if (num_errors > 0) {
+        log_error("Stopping the program after %u errors found in XDC file\n", num_errors);
+    }
 }
 
 NEXTPNR_NAMESPACE_END


### PR DESCRIPTION
This is an update of parsing of XDC commands based on recent merge in nextpnr, for Himbaechel backend.
It makes it possible to have the same xdc file for vivado and nextpnr, for source languages verilog and vhdl (after ghdl).