### PR TITLE
xdc: Handle get_ports args with braces and spaces

### DIFF
--- a/xilinx/xdc.cc
+++ b/xilinx/xdc.cc
@@ -81,14 +81,15 @@ void Arch::parseXdc(std::istream &in)
         if (str.empty() || str.front() != '[')
             log_error("failed to parse target (on line %d)\n", lineno);
         str = str.substr(1, str.size() - 2);
-        auto split = split_to_args(str, false);
+        auto split = split_to_args(str, true);
         if (split.size() < 1)
             log_error("failed to parse target (on line %d)\n", lineno);
         if (split.front() != "get_ports")
             log_error("targets other than 'get_ports' are not supported (on line %d)\n", lineno);
         if (split.size() < 2)
             log_error("failed to parse target (on line %d)\n", lineno);
-        IdString cellname = id(strip_quotes(split.at(1)));
+        auto cellnames = split_to_args(strip_quotes(split.at(1)), false); // Handle braces
+        IdString cellname = id(cellnames.at(0));
         if (cells.count(cellname))
             tgt_cells.push_back(cells.at(cellname).get());
         return tgt_cells;

--- a/xilinx/xdc.cc
+++ b/xilinx/xdc.cc
@@ -100,14 +100,18 @@ void Arch::parseXdc(std::istream &in)
         if (str.empty() || str.front() != '[')
             log_error("failed to parse target (on line %d)\n", lineno);
         str = str.substr(1, str.size() - 2);
-        auto split = split_to_args(str, false);
+        auto split = split_to_args(str, true);
         if (split.size() < 1)
             log_error("failed to parse target (on line %d)\n", lineno);
         if (split.front() != "get_ports" && split.front() != "get_nets")
             log_error("targets other than 'get_ports' or 'get_nets' are not supported (on line %d)\n", lineno);
         if (split.size() < 2)
             log_error("failed to parse target (on line %d)\n", lineno);
-        IdString netname = id(split.at(1));
+        auto netnames = split_to_args(strip_quotes(split.at(1)), false);
+        str = netnames.at(0);
+        if (str.empty())
+            return tgt_nets;
+        IdString netname = id(str);
         NetInfo *maybe_net = getNetByAlias(netname);
         if (maybe_net != nullptr)
             tgt_nets.push_back(maybe_net);


### PR DESCRIPTION
I ran into an issue using nextpnr-xilinx with a Digilent Arty A7 board (rev E), using [their provided xdc file](https://github.com/Digilent/digilent-xdc/blob/master/Arty-A7-100-Master.xdc). It doesn't seem like the current xdc parsing can handle stuff like 

```set_property -dict { PACKAGE_PIN A8    IOSTANDARD LVCMOS33 } [get_ports { sw[0] }]```

where the argument to `get_ports` has braces *and* whitespace. Either `get_ports {sw[0]}` or `get_ports sw[0]` works just fine, but `get_ports { sw[0] }` errors out. This PR fixes that by adding a second `split_to_args` call in `get_cells`.